### PR TITLE
Adding release information

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -174,6 +174,47 @@ class github_api {
 	}
 
 
+	
+	/**
+	 * Get release information for repository, used to determine if any releases exist
+	 * @param  string $owner      The repository's owner
+	 * @param  string $repository The respository name
+	 * @return object             The response from the GitHub API
+	 */
+	public function get_repo_releases( $owner, $repository ) {
+
+		$this->log( "get_repo_releases( $owner, $repository )", GEDEBUG_CALL );
+
+		$owner = trim( $owner, '/' );
+		$repo = trim( $repository, '/' );
+
+		$results = $this->call_api( "https://api.github.com/repos/$owner/$repo/releases" );
+
+		return json_decode( $results['body'] );
+
+	}
+	
+	
+	/**
+	 * Get latest release information for repository.
+	 * @param  string $owner      The repository's owner
+	 * @param  string $repository The respository name
+	 * @return object             The response from the GitHub API
+	 */
+	public function get_repo_releases_latest( $owner, $repository ) {
+
+		$this->log( "get_repo_releases_latest( $owner, $repository )", GEDEBUG_CALL );
+
+		$owner = trim( $owner, '/' );
+		$repo = trim( $repository, '/' );
+
+		$results = $this->call_api( "https://api.github.com/repos/$owner/$repository/releases/latest" );
+
+		return json_decode( $results['body'] );
+
+	}
+
+
 
 	/**
 	 * Get a user from the GitHub API

--- a/github-embed.php
+++ b/github-embed.php
@@ -325,6 +325,7 @@ class github_embed {
 
 		$repo = $this->api->get_repo ( $owner, $repository );
 		$commits =$this->api->get_repo_commits ( $owner, $repository );
+		$releases = $this->api->get_repo_releases ( $owner, $repository );
 
 		$response = new stdClass();
 		$response->type = 'rich';
@@ -337,6 +338,24 @@ class github_embed {
 		$response->html = '<div class="github-embed github-embed-repository">';
 		$response->html .= '<p><a href="'.esc_attr($repo->html_url).'" target="_blank"><strong>'.esc_html($repo->description)."</strong></a><br/>";
 		$response->html .= '<a href="'.esc_attr($repo->html_url).'" target="_blank">'.esc_html($repo->html_url)."</a><br/>";
+		
+		
+		/*
+		 * Show the latest release if one exists, otherwise show Latest release: none.
+		 */
+		if ( $releases == null )
+		{
+			$response->html .= "Latest release: none<br />";
+		}
+		else
+		{
+			$latest_release = $this->api->get_repo_releases_latest ( $owner, $repository );
+			$latest_release_url = $latest_release->html_url;
+			$latest_release_tag = $latest_release->tag_name;
+			$response->html .= 'Latest release: <a href="' . $latest_release_url . '" target="_blank">' . 
+				$latest_release_tag . '</a><br />';
+		}
+		
 		$response->html .= '<a href="'.esc_attr($repo->html_url . '/network') . '" target="_blank">'.esc_html ( number_format_i18n ( $repo->forks_count ) ) . "</a> forks.<br/>";
 		$response->html .= '<a href="'.esc_attr($repo->html_url . '/stargazers') . '" target="_blank">'.esc_html ( number_format_i18n ( $repo->stargazers_count ) ) . "</a> stars.<br/>";
 		$response->html .= '<a href="'.esc_attr($repo->html_url . '/issues') . '" target="_blank">'.esc_html ( number_format_i18n ( $repo->open_issues_count ) ) . "</a> open issues.<br/>";


### PR DESCRIPTION
I have added two new functions to the API Class

The first is "public function get_repo_releases ( $owner, $repository )" which retrieves the response of "https://api.github.com/repos/$owner/$repo/releases" to determine if the specified repo has any releases.

The second is "public function get_repo_releases_latest ( $owner, $repository )" which retrieves the response of "https://api.github.com/repos/$owner/$repo/releases/latest" to gain access to the html_url and tag_name attributes.

Finally I have included code to "private function oembed_github_repo ( $owner, $repository )" to check if any releases exist, and if so to include a link to the latest release.

If no releases are available "Latest release: none" is displayed above forks. If one or more releases exist "Latest release: <release tag>" is displayed above forks, where <release tag> is the version of the latest release, which is surround by an anchor tag linking to the latest release page on Github.

Jim Valentine
<img width="623" alt="screen shot 2016-06-23 at 10 27 27" src="https://cloud.githubusercontent.com/assets/18120373/16304768/cb307948-394e-11e6-9c10-3dc64c41aaf0.png">
