### PR TITLE
Create a template to look like github's repo preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /nbproject/
+.remote-sync.json

--- a/css/github-embed.css
+++ b/css/github-embed.css
@@ -24,58 +24,58 @@ li.github-repo-contributor {
 	margin-bottom: 0.5em;
 }
 
-.github-embed-repository{
+
+.github-oembed-repository{
     padding-top: 16px!important;
     padding-bottom: 16px!important;
     border-bottom: 1px #e1e4e8 solid !important
 }
-.d-flex{
+.github-oembed-container{
     display: flex;
 }
-.d-block{
+
+.github-oembed-avatar-block{
     display: block;
-}
-.d-inline-block{
-    display: inline-block;
-}
-.mr-3{
     margin-right: 16px;
-}
-.mt-1{
     margin-top:4px;
 }
-.mb-1{
-    margin-bottom:4px;
-}
-.mb-1{
-    margin-bottom:8px;
-}
-.pr-4{
-    padding-right: 24px;
-}
-.f6{
-    font-size:80%;
-}
-.text-gray{
-    color: #586069;
-}
-.d-flex a.muted-link{
-    text-decoration: none;
-    color: #586069 !important;
-}
-.avatar{
+.github-oembed-avatar{
     display: inline-block;
     overflow: hidden;
     line-height: 1;
     vertical-align: middle;
     border-radius: 3px;
 }
-.octicon {
+.github-oembed-title-block{
     display: inline-block;
-    vertical-align: text-bottom;
-    fill: currentColor;
+    margin-bottom:8px;
 }
-.repo-language-color {
+.github-oembed-forkedfrom{
+    font-size:80%;
+    color: #586069;
+    margin-bottom:4px;
+}
+
+.github-oembed-description{
+    color: #586069;
+    margin-bottom:8px;
+    padding-right: 24px;
+}
+
+.github-oembed-details-block{
+    font-size:80%;
+    margin-top:4px;
+    color: #586069;
+}
+.github-oembed-detail-label{
+    margin-right: 16px;
+}
+.github-oembed-details-block a.github-oembed-detail-link{
+    text-decoration: none;
+    color: #586069 !important;
+}
+
+.github-oembed-repo-language{
     position: relative;
     top: 1px;
     display: inline-block;
@@ -83,6 +83,14 @@ li.github-repo-contributor {
     height: 12px;
     border-radius: 50%;
 }
+
+.github-oembed-detail-icon {
+    display: inline-block;
+    vertical-align: text-bottom;
+    fill: currentColor;
+}
+
+/* This list is probably not complete yet */
 .repo-language-color.lang_php{
     background-color: #4F5D95;
 }

--- a/css/github-embed.css
+++ b/css/github-embed.css
@@ -23,3 +23,81 @@ li.github-repo-contributor {
 	margin-right: 1em;
 	margin-bottom: 0.5em;
 }
+
+.github-embed-repository{
+    padding-top: 16px!important;
+    padding-bottom: 16px!important;
+    border-bottom: 1px #e1e4e8 solid !important
+}
+.d-flex{
+    display: flex;
+}
+.d-block{
+    display: block;
+}
+.d-inline-block{
+    display: inline-block;
+}
+.mr-3{
+    margin-right: 16px;
+}
+.mt-1{
+    margin-top:4px;
+}
+.mb-1{
+    margin-bottom:4px;
+}
+.mb-1{
+    margin-bottom:8px;
+}
+.pr-4{
+    padding-right: 24px;
+}
+.f6{
+    font-size:80%;
+}
+.text-gray{
+    color: #586069;
+}
+.d-flex a.muted-link{
+    text-decoration: none;
+    color: #586069 !important;
+}
+.avatar{
+    display: inline-block;
+    overflow: hidden;
+    line-height: 1;
+    vertical-align: middle;
+    border-radius: 3px;
+}
+.octicon {
+    display: inline-block;
+    vertical-align: text-bottom;
+    fill: currentColor;
+}
+.repo-language-color {
+    position: relative;
+    top: 1px;
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+}
+.repo-language-color.lang_php{
+    background-color: #4F5D95;
+}
+.repo-language-color.lang_css{
+    background-color: #563d7c;
+}
+.repo-language-color.lang_js{
+    background-color: #f1e05a;
+}
+.repo-language-color.lang_python{
+    background-color: #3572A5;
+}
+.repo-language-color.lang_tex{
+    background-color: #3D6117;
+}
+.repo-language-color.lang_shell{
+    background-color: #89e051;
+}

--- a/css/github-embed.css
+++ b/css/github-embed.css
@@ -91,21 +91,21 @@ li.github-repo-contributor {
 }
 
 /* This list is probably not complete yet */
-.repo-language-color.lang_php{
+.github-oembed-repo-language.lang_php{
     background-color: #4F5D95;
 }
-.repo-language-color.lang_css{
+.github-oembed-repo-language.lang_css{
     background-color: #563d7c;
 }
-.repo-language-color.lang_js{
+.github-oembed-repo-language.lang_javascript{
     background-color: #f1e05a;
 }
-.repo-language-color.lang_python{
+.github-oembed-repo-language.lang_python{
     background-color: #3572A5;
 }
-.repo-language-color.lang_tex{
+.github-oembed-repo-language.lang_tex{
     background-color: #3D6117;
 }
-.repo-language-color.lang_shell{
+.github-oembed-repo-language.lang_shell{
     background-color: #89e051;
 }

--- a/github-embed.php
+++ b/github-embed.php
@@ -273,23 +273,25 @@ class github_embed {
 		$response->version = '1.0';
 		$response->title = $repo->description;
 
-                // Include template file
-                // @TODO: there should be an option to select different templates!
-                $includepath = plugin_dir_path( __FILE__ ) . 'templates/repo_default.php';
-                
-                // Start rendering
+    // Include template file
+    // @TODO: there should be an option to select different templates!
+		if( locate_template('github-oembed-repo.php') ){
+			$includepath = locate_template('github-oembed-repo.php');
+		} else {
+			$includepath = plugin_dir_path( __FILE__ ) . 'templates/repo_default.php';
+		}
+
 		ob_start();
-		// Include the recipe template file:
-                include( $includepath );
+    // Include the recipe template file:
+    include( $includepath );
 		// and render the content using that file:
+
 		$content = ob_get_contents();
-		// Finish rendering
 		ob_end_clean();
-		
-                // Add to response opbject
-                $response->html = $content;
-		
-                header( 'Content-Type: application/json' );
+    // Add to response opbject
+    $response->html = $content;
+
+    header( 'Content-Type: application/json' );
 		echo json_encode( $response );
 		die();
 	}

--- a/github-embed.php
+++ b/github-embed.php
@@ -273,33 +273,23 @@ class github_embed {
 		$response->version = '1.0';
 		$response->title = $repo->description;
 
-		// @TODO This should all be templated
-		$response->html = '<div class="github-embed github-embed-repository">';
-		$response->html .= '<p><a href="' . esc_attr( $repo->html_url ) . '" target="_blank"><strong>' . esc_html( $repo->description ) . '</strong></a><br/>';
-		$response->html .= '<a href="' . esc_attr( $repo->html_url ) . '" target="_blank">' . esc_html( $repo->html_url ) . '</a><br/>';
-		$response->html .= '<a href="' . esc_attr( $repo->html_url . '/network' ) . '" target="_blank">' . esc_html( number_format_i18n( $repo->forks_count ) ) . '</a> forks.<br/>';
-		$response->html .= '<a href="' . esc_attr( $repo->html_url . '/stargazers' ) . '" target="_blank">' . esc_html( number_format_i18n( $repo->stargazers_count ) ) . '</a> stars.<br/>';
-		$response->html .= '<a href="' . esc_attr( $repo->html_url . '/issues' ) . '" target="_blank">' . esc_html( number_format_i18n( $repo->open_issues_count ) ) . '</a> open issues.<br/>';
-
-		if ( count( $commits ) ) {
-			$cnt = 0;
-			$response->html .= 'Recent commits:';
-			$response->html .= '<ul class="github_commits">';
-			foreach ( $commits as $commit ) {
-				if ( $cnt > 4 ) {
-					break;
-				}
-				$response->html .= '<li class="github_commit">';
-				$response->html .= '<a href="https://github.com/' . $owner . '/' . $repository . '/commit/' . esc_attr( $commit->sha ) . '" target="_blank">' . esc_html( $commit->commit->message ) . '</a>, ';
-				$response->html .= esc_html( $commit->commit->committer->name );
-				$response->html .= '</li>';
-				$cnt++;
-			}
-			$response->html .= '</ul>';
-		}
-		$response->html .= '</p>';
-		$response->html .= '</div>';
-		header( 'Content-Type: application/json' );
+                // Include template file
+                // @TODO: there should be an option to select different templates!
+                $includepath = plugin_dir_path( __FILE__ ) . 'templates/repo_default.php';
+                
+                // Start rendering
+		ob_start();
+		// Include the recipe template file:
+                include( $includepath );
+		// and render the content using that file:
+		$content = ob_get_contents();
+		// Finish rendering
+		ob_end_clean();
+		
+                // Add to response opbject
+                $response->html = $content;
+		
+                header( 'Content-Type: application/json' );
 		echo json_encode( $response );
 		die();
 	}

--- a/templates/repo_default.php
+++ b/templates/repo_default.php
@@ -1,0 +1,79 @@
+<?php
+
+/* 
+ * Default template for github repositiories
+ */
+// @TODO: Add microdata!
+// @TODO add relative time formats for the "Updated" string
+?>
+<div class="github-embed-repository">
+    
+
+    <!-- Container with all the info -->
+    <div class="d-flex">
+<!-- Avatar -->
+    <a class="d-block mr-3 mt-1" href="<?php echo esc_url( $repo->owner->html_url ); ?>">
+        <img src="<?php echo esc_url( $repo->owner->avatar_url ); ?>" class="avatar rounded-1" alt="@<?php echo $owner; ?>" width="48" height="48">
+    </a>
+      <!-- Title -->
+      <div>
+        <div class="d-inline-block mb-1">
+          <h3>
+            <a href="<?php echo $repo->html_url; ?>">
+              <span class="text-normal"><?php echo $owner; ?>/</span><?php echo $repository; ?></a>          
+          </h3>
+        </div>
+
+        <?php if( $repo->parent ){ ?>
+            <span class="f6 text-gray mb-1">
+              Forked from <a href="<?php echo $repo->parent->html_url?>"><?php echo $repo->parent->full_name; ?></a>
+            </span>
+        <?php } ?>
+
+          <p class="text-gray mb-2 pr-4" itemprop="description"><?php echo esc_html( $repo->description ); ?></p>
+
+
+        <div class="f6 text-gray mt-2">
+              <span class="repo-language-color ml-0 lang_<?php echo strtolower(esc_attr($repo->language)); ?>"></span>
+            <span class="mr-3" itemprop="programmingLanguage"><?php echo esc_attr( $repo->language ); ?> </span>
+            <?php if( $repo->stargazers_count > 0) { ?>
+            <a class="muted-link mr-3" href="<?php esc_url( $repo->stargazers_url ); ?>">
+              <svg aria-label="star" class="octicon octicon-star" viewBox="0 0 14 16" version="1.1" width="14" height="16" role="img"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"></path></svg>
+              <?php echo esc_attr( $repo->stargazers_count ); ?>
+            </a>
+            <?php } ?>
+
+            <?php if( $repo->network_count > 0 ){ ?>
+                <a class="muted-link mr-3" href="<?php echo esc_url( $repo->html_url); ?>/network">
+                  <svg aria-label="fork" class="octicon octicon-repo-forked" viewBox="0 0 10 16" version="1.1" width="10" height="16" role="img"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path></svg>
+                    <?php echo esc_attr($repo->network_count); ?>
+                </a>
+            <?php } ?>
+
+            <?php if( $repo->license->spdx_id ){ ?>
+            <span class="mr-3">
+              <svg class="octicon octicon-law mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 4c-.83 0-1.5-.67-1.5-1.5S6.17 1 7 1s1.5.67 1.5 1.5S7.83 4 7 4zm7 6c0 1.11-.89 2-2 2h-1c-1.11 0-2-.89-2-2l2-4h-1c-.55 0-1-.45-1-1H8v8c.42 0 1 .45 1 1h1c.42 0 1 .45 1 1H3c0-.55.58-1 1-1h1c0-.55.58-1 1-1h.03L6 5H5c0 .55-.45 1-1 1H3l2 4c0 1.11-.89 2-2 2H2c-1.11 0-2-.89-2-2l2-4H1V5h3c0-.55.45-1 1-1h4c.55 0 1 .45 1 1h3v1h-1l2 4zM2.5 7L1 10h3L2.5 7zM13 10l-1.5-3-1.5 3h3z"></path></svg>
+                <?php echo esc_attr( $repo->license->spdx_id ); ?>
+            </span>
+            <?php } ?>
+
+            <?php if( $repo->has_issues and $repo->open_issues_count > 0 ){ ?>
+            <a class="muted-link mr-3" href="<?php echo esc_url( $repo->issues_url ); ?>">
+                <?php if ($repo->open_issues_count == 1 ){ ?>
+                    1 issue needs help
+                <?php } else { ?>
+                    <?php echo esc_attr( $repo->open_issues_count ); ?> issues need help
+                <?php } ?>
+             </a>
+            <?php } ?>
+
+            Updated on <?php echo date( "j M Y", strtotime( esc_attr( $repo->updated_at ) ) ); ?>
+        </div>
+      </div>
+    </div>
+    
+
+<?php //echo "<pre>"; ?>
+<?php //var_dump($repo); ?>
+<?php //echo "</pre>"; ?>
+</div>

--- a/templates/repo_default.php
+++ b/templates/repo_default.php
@@ -6,59 +6,61 @@
 // @TODO: Add microdata!
 // @TODO add relative time formats for the "Updated" string
 ?>
-<div class="github-embed-repository">
+<div class="github-oembed github-embed-repository">
     
 
     <!-- Container with all the info -->
-    <div class="d-flex">
+    <div class="github-oembed-container">
 <!-- Avatar -->
-    <a class="d-block mr-3 mt-1" href="<?php echo esc_url( $repo->owner->html_url ); ?>">
-        <img src="<?php echo esc_url( $repo->owner->avatar_url ); ?>" class="avatar rounded-1" alt="@<?php echo $owner; ?>" width="48" height="48">
+    <a class="github-oembed-avatar-block" href="<?php echo esc_url( $repo->owner->html_url ); ?>">
+        <img src="<?php echo esc_url( $repo->owner->avatar_url ); ?>" class="github-oembed-avatar rounded-1" alt="@<?php echo $owner; ?>" width="48" height="48">
     </a>
       <!-- Title -->
       <div>
-        <div class="d-inline-block mb-1">
+        <div class="github-oembed-title-block">
           <h3>
             <a href="<?php echo $repo->html_url; ?>">
-              <span class="text-normal"><?php echo $owner; ?>/</span><?php echo $repository; ?></a>          
+              <span class="github-oembed-title-owner"><?php echo $owner; ?></span>/<span class="github-oembed-title-repo"><?php echo $repository; ?></span>
+            </a>          
           </h3>
         </div>
 
         <?php if( $repo->parent ){ ?>
-            <span class="f6 text-gray mb-1">
+            <span class="github-oembed-forkedfrom">
               Forked from <a href="<?php echo $repo->parent->html_url?>"><?php echo $repo->parent->full_name; ?></a>
             </span>
         <?php } ?>
+        
+        <!-- Description -->
+        <p class="github-oembed-description"><?php echo esc_html( $repo->description ); ?></p>
 
-          <p class="text-gray mb-2 pr-4" itemprop="description"><?php echo esc_html( $repo->description ); ?></p>
-
-
-        <div class="f6 text-gray mt-2">
-              <span class="repo-language-color ml-0 lang_<?php echo strtolower(esc_attr($repo->language)); ?>"></span>
-            <span class="mr-3" itemprop="programmingLanguage"><?php echo esc_attr( $repo->language ); ?> </span>
+        <!-- Details -->
+        <div class="github-oembed-details-block">
+              <span class="github-oembed-repo-language lang_<?php echo strtolower(esc_attr($repo->language)); ?>"></span>
+            <span class="github-oembed-detail-label" ><?php echo esc_attr( $repo->language ); ?> </span>
             <?php if( $repo->stargazers_count > 0) { ?>
-            <a class="muted-link mr-3" href="<?php esc_url( $repo->stargazers_url ); ?>">
-              <svg aria-label="star" class="octicon octicon-star" viewBox="0 0 14 16" version="1.1" width="14" height="16" role="img"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"></path></svg>
+            <a class="github-oembed-detail-link github-oembed-detail-label" href="<?php esc_url( $repo->stargazers_url ); ?>">
+              <svg aria-label="star" class="github-oembed-detail-icon .github-oembed-detail-icon-star" viewBox="0 0 14 16" version="1.1" width="14" height="16" role="img"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"></path></svg>
               <?php echo esc_attr( $repo->stargazers_count ); ?>
             </a>
             <?php } ?>
 
             <?php if( $repo->network_count > 0 ){ ?>
-                <a class="muted-link mr-3" href="<?php echo esc_url( $repo->html_url); ?>/network">
-                  <svg aria-label="fork" class="octicon octicon-repo-forked" viewBox="0 0 10 16" version="1.1" width="10" height="16" role="img"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path></svg>
+                <a class="github-oembed-detail-link github-oembed-detail-label" href="<?php echo esc_url( $repo->html_url); ?>/network">
+                  <svg aria-label="fork" class="github-oembed-detail-icon github-oembed-detail-icon-repo-forked" viewBox="0 0 10 16" version="1.1" width="10" height="16" role="img"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path></svg>
                     <?php echo esc_attr($repo->network_count); ?>
                 </a>
             <?php } ?>
 
             <?php if( $repo->license->spdx_id ){ ?>
-            <span class="mr-3">
-              <svg class="octicon octicon-law mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 4c-.83 0-1.5-.67-1.5-1.5S6.17 1 7 1s1.5.67 1.5 1.5S7.83 4 7 4zm7 6c0 1.11-.89 2-2 2h-1c-1.11 0-2-.89-2-2l2-4h-1c-.55 0-1-.45-1-1H8v8c.42 0 1 .45 1 1h1c.42 0 1 .45 1 1H3c0-.55.58-1 1-1h1c0-.55.58-1 1-1h.03L6 5H5c0 .55-.45 1-1 1H3l2 4c0 1.11-.89 2-2 2H2c-1.11 0-2-.89-2-2l2-4H1V5h3c0-.55.45-1 1-1h4c.55 0 1 .45 1 1h3v1h-1l2 4zM2.5 7L1 10h3L2.5 7zM13 10l-1.5-3-1.5 3h3z"></path></svg>
+            <span class="github-oembed-detail-label">
+              <svg class="github-oembed-detail-icon github-oembed-detail-icon-law" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 4c-.83 0-1.5-.67-1.5-1.5S6.17 1 7 1s1.5.67 1.5 1.5S7.83 4 7 4zm7 6c0 1.11-.89 2-2 2h-1c-1.11 0-2-.89-2-2l2-4h-1c-.55 0-1-.45-1-1H8v8c.42 0 1 .45 1 1h1c.42 0 1 .45 1 1H3c0-.55.58-1 1-1h1c0-.55.58-1 1-1h.03L6 5H5c0 .55-.45 1-1 1H3l2 4c0 1.11-.89 2-2 2H2c-1.11 0-2-.89-2-2l2-4H1V5h3c0-.55.45-1 1-1h4c.55 0 1 .45 1 1h3v1h-1l2 4zM2.5 7L1 10h3L2.5 7zM13 10l-1.5-3-1.5 3h3z"></path></svg>
                 <?php echo esc_attr( $repo->license->spdx_id ); ?>
             </span>
             <?php } ?>
 
             <?php if( $repo->has_issues and $repo->open_issues_count > 0 ){ ?>
-            <a class="muted-link mr-3" href="<?php echo esc_url( $repo->issues_url ); ?>">
+            <a class="github-oembed-detail-link github-oembed-detail-label" href="<?php echo esc_url( $repo->issues_url ); ?>">
                 <?php if ($repo->open_issues_count == 1 ){ ?>
                     1 issue needs help
                 <?php } else { ?>
@@ -77,3 +79,4 @@
 <?php //var_dump($repo); ?>
 <?php //echo "</pre>"; ?>
 </div>
+

--- a/templates/repo_default.php
+++ b/templates/repo_default.php
@@ -73,10 +73,5 @@
         </div>
       </div>
     </div>
-    
-
-<?php //echo "<pre>"; ?>
-<?php //var_dump($repo); ?>
-<?php //echo "</pre>"; ?>
 </div>
 

--- a/templates/repo_default.php
+++ b/templates/repo_default.php
@@ -1,13 +1,13 @@
 <?php
 
-/* 
+/*
  * Default template for github repositiories
  */
 // @TODO: Add microdata!
 // @TODO add relative time formats for the "Updated" string
 ?>
-<div class="github-oembed github-embed-repository">
-    
+<div class="github-oembed github-oembed-repository">
+
 
     <!-- Container with all the info -->
     <div class="github-oembed-container">
@@ -21,7 +21,7 @@
           <h3>
             <a href="<?php echo $repo->html_url; ?>">
               <span class="github-oembed-title-owner"><?php echo $owner; ?></span>/<span class="github-oembed-title-repo"><?php echo $repository; ?></span>
-            </a>          
+            </a>
           </h3>
         </div>
 
@@ -30,14 +30,17 @@
               Forked from <a href="<?php echo $repo->parent->html_url?>"><?php echo $repo->parent->full_name; ?></a>
             </span>
         <?php } ?>
-        
+
         <!-- Description -->
         <p class="github-oembed-description"><?php echo esc_html( $repo->description ); ?></p>
 
         <!-- Details -->
         <div class="github-oembed-details-block">
+            <?php if( $repo->language != '' ) { ?>
               <span class="github-oembed-repo-language lang_<?php echo strtolower(esc_attr($repo->language)); ?>"></span>
-            <span class="github-oembed-detail-label" ><?php echo esc_attr( $repo->language ); ?> </span>
+              <span class="github-oembed-detail-label" ><?php echo esc_attr( $repo->language ); ?> </span>
+            <?php } ?>
+
             <?php if( $repo->stargazers_count > 0) { ?>
             <a class="github-oembed-detail-link github-oembed-detail-label" href="<?php esc_url( $repo->stargazers_url ); ?>">
               <svg aria-label="star" class="github-oembed-detail-icon .github-oembed-detail-icon-star" viewBox="0 0 14 16" version="1.1" width="14" height="16" role="img"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"></path></svg>
@@ -74,4 +77,3 @@
       </div>
     </div>
 </div>
-


### PR DESCRIPTION
I've created a first template for github repositories to look quite a lot like github's own  repo preview.
If you like the idea, I could also create templates for the remaining embeds.

I could also imagine to add an option to select bewteen a more classic view (using the github octocat icon) and a more github like.